### PR TITLE
Fixed NSStatusItem's deprecated API.

### DIFF
--- a/NinjaMode/AppDelegate.m
+++ b/NinjaMode/AppDelegate.m
@@ -27,7 +27,6 @@
     statusBarButton.image = [NSImage imageNamed:@"switchIcon.png"];
     [statusBarButton.image setTemplate:YES];
     
-    _statusItem.highlightMode = NO;
     statusButton.highlighted = NO;
     statusBarButton.toolTip = @"control-click to quit";
     

--- a/NinjaMode/AppDelegate.m
+++ b/NinjaMode/AppDelegate.m
@@ -3,6 +3,7 @@
 //  NinjaMode
 //
 //  Created by Nirbhay Agarwal on 08/10/14.
+//  Updated by Benedikt-Alexander Mokroß on 21/04/2017 (Fixed depricated API).
 //  Copyright (c) 2014 NSRover. All rights reserved.
 //
 
@@ -21,13 +22,16 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
-    _statusItem.image = [NSImage imageNamed:@"switchIcon.png"];
-    [_statusItem.image setTemplate:YES];
+    
+    NSStatusBarButton* statusBarButton = _statusItem.button;
+    statusBarButton.image = [NSImage imageNamed:@"switchIcon.png"];
+    [statusBarButton.image setTemplate:YES];
     
     _statusItem.highlightMode = NO;
-    _statusItem.toolTip = @"control-click to quit";
+    statusButton.highlighted = NO;
+    statusBarButton.toolTip = @"control-click to quit";
     
-    [_statusItem setAction:@selector(itemClicked:)];
+    [statusBarButton setAction:@selector(itemClicked:)];
     
     [self refreshDarkMode];
 }


### PR DESCRIPTION
Apples's new way to work with the `NSStatusItem` is to use the `NSStatusBarButton` available with `_statusItem.button`